### PR TITLE
fix: module compression incorrectly reused first file's root pointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "leangz"
-version = "0.1.16-pre3"
+version = "0.1.16-pre4"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leangz"
-version = "0.1.16-pre3"
+version = "0.1.16-pre4"
 edition = "2021"
 default-run = "leangz"
 

--- a/src/lgz.rs
+++ b/src/lgz.rs
@@ -258,7 +258,7 @@ pub fn compress(oleans: &[&[u8]], outfile: impl Write) {
     end = end.next_multiple_of(1 << 16);
     assert_eq!(end, header2.base);
     end += olean.len() as u64;
-    data.push(Data { root, offset: (header2.offset - offset) as usize, rest });
+    data.push(Data { root: header2.root, offset: (header2.offset - offset) as usize, rest });
   }
   let VHeader { githash, lean_version } = vheader;
   let len = {
@@ -276,7 +276,7 @@ pub fn compress(oleans: &[&[u8]], outfile: impl Write) {
       pos = on_subobjs(cfg, d.rest, pos, &mut f);
       pos = pad_to(pos, 8).1;
     }
-    f(root);
+    f(d.root);
   }
   let mut w = LgzWriter {
     cfg,


### PR DESCRIPTION
## Summary

Fixes a bug in the module compression feature where `.olean.server` and `.olean.private` files were being truncated to 96 bytes (just the header) instead of being fully compressed.

**Note:** This diagnosis and fix were performed by Claude Code (@anthropics). While integration tests pass, this needs careful review by @digama0 to ensure correctness, as I (@kim-em) cannot vouch for the implementation details.

## The Bug

Two related issues in `src/lgz.rs` `compress()` function:

1. **Line 261:** Used `root` instead of `header2.root` when storing each file's metadata
   - Caused all `Data` entries to reference the same root object from the first file
   
2. **Line 279:** Used `root` instead of `d.root` during reference counting
   - Only marked the first file's root as referenced

## Symptom

When compressing three module files (`.olean`, `.olean.server`, `.olean.private`):
- ✅ First file (`.olean`): Compressed correctly → ~48KB
- ❌ Second file (`.server`): Decompressed to 96 bytes instead of 2.3KB
- ❌ Third file (`.private`): Decompressed to 96 bytes instead of 46KB

The second and third files were truncated because the compressor's backref cache thought it had already written their root objects (since all three files pointed to the first file's root).

## The Fix

Two one-line changes in `src/lgz.rs`:
1. Line 261: `root` → `header2.root`
2. Line 279: `root` → `d.root`

Each file now correctly stores and compresses its own root pointer, producing three complete, distinct object graphs.

## Testing

#4 added integration tests in `tests/module_compression.rs` with test data from `Plausible.Attr` module.

**Before fix:**
```
✓ test_single_olean_roundtrip: PASSED
✗ test_module_roundtrip: FAILED
  - Attr.olean.server: 2344 bytes → 96 bytes (truncated!)
  - Attr.olean.private: 47320 bytes → 96 bytes (truncated!)
```

**After fix:**
```
✓ test_single_olean_roundtrip: PASSED  
✓ test_module_roundtrip: PASSED
  - Attr.olean:         48976 bytes ✓
  - Attr.olean.server:  2344 bytes ✓
  - Attr.olean.private: 47320 bytes ✓
```

cc @digama0 for review